### PR TITLE
Validate checks along with services.

### DIFF
--- a/lighthouse/check.py
+++ b/lighthouse/check.py
@@ -150,13 +150,13 @@ class Check(Pluggable):
         cls.validate_check_config(config)
 
     @classmethod
-    def from_config(cls, service, name, config):
+    def from_config(cls, name, host, port, config):
         """
         Behaves like the base Configurable class's `from_config()` except this
         method transfers the given service's host and port to the config.
         """
-        config["host"] = service.host
-        config["port"] = service.port
+        config["host"] = host
+        config["port"] = port
 
         return super(Check, cls).from_config(name, config)
 

--- a/lighthouse/service.py
+++ b/lighthouse/service.py
@@ -45,6 +45,14 @@ class Service(Configurable):
         if "discovery" not in config:
             raise ValueError("No discovery method defined.")
 
+        for check_name, check_config in six.iteritems(config["checks"]):
+            if check_name == "interval":
+                continue
+
+            Check.from_config(
+                check_name, config["host"], config["port"], check_config
+            )
+
     def apply_config(self, config):
         """
         Takes a given validated config dictionary and sets an instance
@@ -73,7 +81,7 @@ class Service(Configurable):
                     self.checks[check_name].apply_config(check_config)
                 else:
                     self.checks[check_name] = Check.from_config(
-                        self, check_name, check_config
+                        check_name, self.host, self.port, check_config
                     )
             except ValueError as e:
                 logger.error(

--- a/tests/check_tests.py
+++ b/tests/check_tests.py
@@ -346,9 +346,8 @@ class BaseCheckTests(unittest.TestCase):
         get_installed.return_value = {
             "fakecheck": fake_check_class
         }
-        service = Mock(host="serv03", port=8001)
 
-        result = Check.from_config(service, "fakecheck", {"foo": "bar"})
+        result = Check.from_config("fakecheck", "serv03", 8001, {"foo": "bar"})
 
         self.assertEqual(result, fake_check_class.return_value)
 
@@ -366,8 +365,5 @@ class BaseCheckTests(unittest.TestCase):
 
         self.assertRaises(
             ValueError,
-            Check.from_config,
-            Mock(host="serv01", port=8888),
-            "othercheck",
-            {"foo": "bar"}
+            Check.from_config, "othercheck", "serv01", 8888, {"foo": "bar"}
         )

--- a/tests/service_tests.py
+++ b/tests/service_tests.py
@@ -85,7 +85,7 @@ class ServiceTests(unittest.TestCase):
         self.assertEqual(service.checks, {})
 
         Check.from_config.assert_called_once_with(
-            service, "http", {"host": "localhost", "port": 8888}
+            "http", "localhost", 3333, {"host": "localhost", "port": 8888}
         )
 
     @patch("lighthouse.service.Check")


### PR DESCRIPTION
Before this patch a call to validate_config() for a service would skip
over the individual check validation, so that if for example an http
check was missing its "uri" it would go unnoticed.