### PR TITLE
Add a new TCP health check, update the extra Redis check

### DIFF
--- a/docs/code/checks.rst
+++ b/docs/code/checks.rst
@@ -5,3 +5,4 @@ Service Checks
 .. toctree::
 
    modules/checks.http
+   modules/checks.tcp

--- a/docs/code/modules/checks.tcp.rst
+++ b/docs/code/modules/checks.tcp.rst
@@ -1,0 +1,7 @@
+``lighthouse.checks.tcp``
+=============================
+
+.. automodule:: lighthouse.checks.tcp
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/configuration/services.rst
+++ b/docs/configuration/services.rst
@@ -81,12 +81,12 @@ Health Check Settings
 Included Health Checks
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The Lighthouse project comes bundled with one health check by default, for
-HTTP-based services.
+The Lighthouse project comes bundled with a handful of health checks by default,
+including two basic ones for HTTP-based services and lower-level TCP services.
 
 
 HTTP
-^^^^^
+^^^^
 
 The HTTP health check performs a simple request to a given uri and passes if
 the response code is in the 2XX range.  The HTTP health check has no extra
@@ -95,6 +95,22 @@ dependencies but does have a required extra setting:
 * **uri** *(required)*:
 
   The uri to hit with an HTTP request to perform the check (e.g. "/health")
+
+TCP
+^^^
+
+The TCP health check can be used for services that don't use HTTP to communicate
+(e.g. redis, kafka, etc.).  The health check is configured to have a "query"
+message sent to the service and an expected "response".
+
+* **query** *(required)*:
+
+  The message to send to the port via TCP (e.g. Zookeeper's "ruok")
+
+* **response** *(required)*
+
+  Expected response from the service.  If the service responds with a different
+  message or an error happens during the process the check will fail.
 
 
 Optional Health Checks

--- a/lighthouse/checks/tcp.py
+++ b/lighthouse/checks/tcp.py
@@ -1,0 +1,106 @@
+import errno
+import logging
+import socket
+
+from lighthouse import check
+
+
+SOCKET_BUFFER_SIZE = 4096
+
+
+logger = logging.getLogger(__name__)
+
+
+class TCPCheck(check.Check):
+    """
+    Service health check using TCP request/response messages.
+
+    Sends a certain message to the configured port and passes if the response
+    is an expected one.
+    """
+
+    name = "tcp"
+
+    def __init__(self, *args, **kwargs):
+        super(TCPCheck, self).__init__(*args, **kwargs)
+
+        self.query = None
+        self.expected_response = None
+
+    @classmethod
+    def validate_dependencies(cls):
+        """
+        This check uses stdlib modules so dependencies are always present.
+        """
+        return True
+
+    @classmethod
+    def validate_check_config(cls, config):
+        """
+        Ensures that a query and expected response are configured.
+        """
+        if "query" not in config:
+            raise ValueError("Missing TCP query message.")
+        if "response" not in config:
+            raise ValueError("Missing expected TCP response message.")
+
+    def apply_check_config(self, config):
+        """
+        Takes the `query` and `response` fields from a validated config
+        dictionary and sets the proper instance attributes.
+        """
+        self.query = config["query"]
+        self.expected_response = config["response"]
+
+    def perform(self):
+        """
+        Performs a straightforward TCP request and response.
+
+        Sends the TCP `query` to the proper host and port, and loops over the
+        socket, gathering response chunks until a full line is acquired.
+
+        If the response line matches the expected value, the check passes. If
+        not, the check fails.  The check will also fail if there's an error
+        during any step of the send/receive process.
+        """
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        sock.connect((self.host, self.port))
+
+        try:
+            sock.sendall(self.query)
+        except Exception:
+            logger.exception("Error sending TCP query message.")
+            sock.close()
+            return False
+
+        response = ""
+
+        while True:
+            try:
+                chunk = sock.recv(SOCKET_BUFFER_SIZE)
+                if chunk:
+                    response += chunk
+            except socket.error as e:
+                if e.errno not in [errno.EAGAIN, errno.EINTR]:
+                    raise
+
+            if not response:
+                break
+
+            if "\n" in response:
+                response, extra = response.split("\n", 1)
+                break
+
+        logger.debug("response: %s", response)
+
+        if response != self.expected_response:
+            logger.warn(
+                "Response does not match expected value: %s (expected %s)",
+                response, self.expected_response
+            )
+            sock.close()
+            return False
+
+        sock.close()
+        return True

--- a/lighthouse/redis/check.py
+++ b/lighthouse/redis/check.py
@@ -2,20 +2,13 @@ from __future__ import absolute_import
 
 import logging
 
-try:
-    from redis import Redis
-    redis_available = True  # pragma: no cover
-except ImportError:
-    redis_available = False
-
-
-from lighthouse.check import Check
+from lighthouse.checks.tcp import TCPCheck
 
 
 logger = logging.getLogger(__name__)
 
 
-class RedisCheck(Check):
+class RedisCheck(TCPCheck):
     """
     Redis service checker.
 
@@ -23,17 +16,6 @@ class RedisCheck(Check):
     """
 
     name = "redis"
-
-    @classmethod
-    def validate_dependencies(cls):
-        """
-        Validates that the redis python library is installed.
-        """
-        if not redis_available:
-            logger.error("Redis check requires the 'redis' library.")
-            return False
-
-        return True
 
     @classmethod
     def validate_check_config(cls, config):
@@ -45,14 +27,8 @@ class RedisCheck(Check):
 
     def apply_check_config(self, config):
         """
-        This method is a no-op as there is no redis-specific configuration
-        available.
+        This method doesn't actually use any configuration data, as the query
+        and response for redis are already established.
         """
-        pass
-
-    def perform(self):
-        """
-        Calls the ping() method on a Redis client connected to the target host
-        and returns the result.
-        """
-        return Redis(host=self.host, port=self.port).ping()
+        self.query = "PING"
+        self.expected_response = "PONG"

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         ],
         "lighthouse.checks": [
             "http = lighthouse.checks.http:HTTPCheck",
+            "tcp = lighthouse.checks.tcp:TCPCheck",
             "redis = lighthouse.redis.check:RedisCheck [redis]",
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,7 @@ setup(
         "six",
     ],
     extras_require={
-        "redis": [
-            "redis"
-        ]
+        "redis": [],
     },
     entry_points={
         "console_scripts": [

--- a/tests/checks/tcp_tests.py
+++ b/tests/checks/tcp_tests.py
@@ -1,0 +1,227 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import errno
+import socket
+
+from mock import patch
+
+from lighthouse.checks.tcp import TCPCheck
+
+
+@patch("lighthouse.checks.tcp.socket")
+class TCPCheckTests(unittest.TestCase):
+
+    def test_no_dependencies(self, mock_socket):
+        self.assertEqual(TCPCheck.validate_dependencies(), True)
+
+    def test_valid_config(self, mock_socket):
+        TCPCheck.validate_check_config({"query": "ruok", "response": "imok"})
+
+    def test_query_required(self, mock_socket):
+        self.assertRaises(
+            ValueError,
+            TCPCheck.validate_check_config,
+            {"response": "imok"}
+        )
+
+    def test_response_required(self, mock_socket):
+        self.assertRaises(
+            ValueError,
+            TCPCheck.validate_check_config,
+            {"query": "imok"}
+        )
+
+    def test_apply_config(self, mock_socket):
+        check = TCPCheck()
+
+        self.assertEqual(check.query, None)
+        self.assertEqual(check.expected_response, None)
+
+        check.apply_check_config({"query": "ruok", "response": "imok"})
+
+        self.assertEqual(check.query, "ruok")
+        self.assertEqual(check.expected_response, "imok")
+
+    def test_error_during_send(self, mock_socket):
+        sock = mock_socket.socket.return_value
+        sock.sendall.side_effect = Exception("oh no!")
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertEqual(check.perform(), False)
+
+        sock.close.assert_called_once_with()
+
+    def test_error_during_connect(self, mock_socket):
+        sock = mock_socket.socket.return_value
+        sock.connect.side_effect = Exception("oh no!")
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertRaises(
+            Exception,
+            check.perform
+        )
+
+    def test_error_during_recv(self, mock_socket):
+        sock = mock_socket.socket.return_value
+        sock.recv.side_effect = Exception("oh no!")
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertRaises(
+            Exception,
+            check.perform
+        )
+
+    def test_mismatch_response(self, mock_socket):
+        sock = mock_socket.socket.return_value
+        sock.recv.return_value = "notok\n"
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertEqual(check.perform(), False)
+
+        sock.sendall.assert_called_once_with("ruok")
+
+        sock.close.assert_called_once_with()
+
+    def test_matching_response(self, mock_socket):
+        sock = mock_socket.socket.return_value
+        sock.recv.return_value = "imok\n"
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertEqual(check.perform(), True)
+
+        sock.sendall.assert_called_once_with("ruok")
+
+        sock.close.assert_called_once_with()
+
+    def test_chunked_response(self, mock_socket):
+        sock = mock_socket.socket.return_value
+
+        chunks = ["im", "ok", "\n"]
+
+        def get_next_chunk(*args):
+            chunk = chunks.pop(0)
+            if isinstance(chunk, Exception):
+                raise chunk
+            else:
+                return chunk
+
+        sock.recv.side_effect = get_next_chunk
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertEqual(check.perform(), True)
+
+        sock.close.assert_called_once_with()
+
+    def test_blank_response(self, mock_socket):
+        sock = mock_socket.socket.return_value
+        sock.recv.return_value = None
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertEqual(check.perform(), False)
+
+        sock.sendall.assert_called_once_with("ruok")
+
+        sock.close.assert_called_once_with()
+
+    def test_recv_interrupted(self, mock_socket):
+        mock_socket.error = socket.error
+        sock = mock_socket.socket.return_value
+
+        again = socket.error(errno.EAGAIN, "try again")
+        interrupt = socket.error(errno.EINTR, "interrupted!")
+
+        chunks = ["im", interrupt, "ok", again, "\n"]
+
+        def get_next_chunk(*args):
+            chunk = chunks.pop(0)
+            if isinstance(chunk, Exception):
+                raise chunk
+            else:
+                return chunk
+
+        sock.recv.side_effect = get_next_chunk
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertEqual(check.perform(), True)
+
+        sock.close.assert_called_once_with()
+
+    def test_recv_socket_error(self, mock_socket):
+        mock_socket.error = socket.error
+        sock = mock_socket.socket.return_value
+
+        interrupt = socket.error(errno.EINTR, "interrupted!")
+        network_down = socket.error(errno.ENETDOWN, "network's down :/")
+
+        chunks = ["im", interrupt, network_down, "ok", "\n"]
+
+        def get_next_chunk(*args):
+            chunk = chunks.pop(0)
+            if isinstance(chunk, Exception):
+                raise chunk
+            else:
+                return chunk
+
+        sock.recv.side_effect = get_next_chunk
+
+        check = TCPCheck()
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "query": "ruok", "response": "imok",
+            "rise": 1, "fall": 1
+        })
+
+        self.assertRaises(
+            socket.error,
+            check.perform
+        )

--- a/tests/redis/check_tests.py
+++ b/tests/redis/check_tests.py
@@ -3,39 +3,17 @@ try:
 except ImportError:
     import unittest
 
-from mock import patch
-
 from lighthouse.redis.check import RedisCheck
 
 
-@patch("lighthouse.redis.check.Redis", create=True)
 class RedisCheckTests(unittest.TestCase):
 
-    @patch("lighthouse.redis.check.redis_available", True)
-    def test_dependency_on_redis(self, StrictRedis):
-        self.assertEqual(RedisCheck.validate_dependencies(), True)
-
-    @patch("lighthouse.redis.check.redis_available", False)
-    def test_dependency_when_redis_not_available(self, StrictRedis):
-        self.assertEqual(RedisCheck.validate_dependencies(), False)
-
-    def test_validate_check_config(self, StrictRedis):
-        self.assertEqual(
-            RedisCheck.validate_check_config({"foo": "bar"}),
-            None
-        )
-
-    def test_perform_just_pings_redis(self, StrictRedis):
+    def test_query_and_response_values(self):
         check = RedisCheck()
-        check.apply_config(
-            {"host": "localhost", "port": 6666, "rise": 1, "fall": 1}
-        )
+        check.apply_config({
+            "host": "127.0.0.1", "port": 1234,
+            "rise": 1, "fall": 1
+        })
 
-        result = check.perform()
-
-        StrictRedis.assert_called_once_with(host="localhost", port=6666)
-
-        self.assertEqual(
-            result,
-            StrictRedis.return_value.ping.return_value
-        )
+        self.assertEqual(check.query, "PING")
+        self.assertEqual(check.expected_response, "PONG")


### PR DESCRIPTION
This will allow for service health checks for non-HTTP services (like kafka or redis, etc.).

It's a simple interface, instead of a URI as in the HTTP check it uses "query" and "response" strings to send and receive to the service.

This update also includes a refactor of the existing Redis check to have it use TCPCheck as a base class and eliminate the check's dependency on the external redis library.