### PR TITLE
Use ThreadPoolExecutor from concurrent.futures.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "pyyaml",
         "kazoo",
         "six",
+        "futures",
     ],
     extras_require={
         "redis": [],


### PR DESCRIPTION
The multiprocessing ThreadPool class is undocumented and not really
meant for use, the ThreadPoolExecutor however is the Way Of The Future.

This should fix a bug where if multiple services were present, the
reporter would only consistently check one of them.