### PR TITLE
Allow for multi-port service definitions.

### DIFF
--- a/docs/configuration/services.rst
+++ b/docs/configuration/services.rst
@@ -31,9 +31,11 @@ the service to be considered "up" and fail only once to be considered "down".
 Settings
 ~~~~~~~~
 
-* **port** *(required)*:
+* **port**/**ports** *(required)*:
 
-  Port that the local service is listening on.
+  Port(s) that the local service is listening on.  If listing multiple ports,
+  the `ports` setting must be used.  For single-port services either `port`
+  or `ports` (with a single entry) will do.
 
 * **discovery** *(required)*:
 

--- a/examples/configs/services/multiapp.yml
+++ b/examples/configs/services/multiapp.yml
@@ -1,6 +1,8 @@
 name: "webapp"
-port: 8002
 discovery: "zookeeper"
+ports:
+  - 8001
+  - 8002
 checks:
   interval: 2
   http:

--- a/examples/configs/services/webapp-8001.yaml
+++ b/examples/configs/services/webapp-8001.yaml
@@ -1,9 +1,0 @@
-name: "webapp"
-port: 8001
-discovery: "zookeeper"
-checks:
-  interval: 2
-  http:
-    rise: 2
-    fall: 3
-    uri: "/health"

--- a/examples/dockerfiles/Dockerfile.multiapp
+++ b/examples/dockerfiles/Dockerfile.multiapp
@@ -3,8 +3,7 @@ FROM lighthouse.examples.base
 COPY configs/haproxy.yaml /etc/lighthouse/
 COPY configs/discovery/zookeeper.yaml /etc/lighthouse/discovery/
 COPY configs/clusters/cache.yaml /etc/lighthouse/clusters/
-COPY configs/services/webapp-8001.yaml /etc/lighthouse/services/
-COPY configs/services/webapp-8002.yaml /etc/lighthouse/services/
+COPY configs/services/multiapp.yaml /etc/lighthouse/services/
 
 RUN virtualenv -p /usr/bin/python2.7 /opt/venvs/webapp
 RUN . /opt/venvs/webapp/bin/activate; pip install flask redis

--- a/lighthouse/check.py
+++ b/lighthouse/check.py
@@ -19,6 +19,12 @@ class Check(Pluggable):
     entry_point = "lighthouse.checks"
 
     def __init__(self):
+        self.host = None
+        self.port = None
+
+        self.rise = None
+        self.fall = None
+
         self.results = deque()
         self.passing = False
 

--- a/lighthouse/check.py
+++ b/lighthouse/check.py
@@ -111,10 +111,8 @@ class Check(Pluggable):
         False results) or contract (by removing the oldest results) until it
         matches the required length.
         """
-        self.host = config["host"]
-        self.port = int(config["port"])
-        self.rise = config["rise"]
-        self.fall = config["fall"]
+        self.rise = int(config["rise"])
+        self.fall = int(config["fall"])
 
         self.apply_check_config(config)
 
@@ -144,32 +142,12 @@ class Check(Pluggable):
         check must pass before being considered passing and how many times a
         check must fail before being considered failing.
         """
-        if "host" not in config:
-            raise ValueError("No host configured")
-        if "port" not in config:
-            raise ValueError("No port configured")
         if "rise" not in config:
             raise ValueError("No 'rise' configured")
         if "fall" not in config:
             raise ValueError("No 'fall' configured")
 
-        try:
-            int(config["port"])
-        except Exception:
-            raise ValueError("Invalid value for 'port'")
-
         cls.validate_check_config(config)
-
-    @classmethod
-    def from_config(cls, name, host, port, config):
-        """
-        Behaves like the base Configurable class's `from_config()` except this
-        method transfers the given service's host and port to the config.
-        """
-        config["host"] = host
-        config["port"] = int(port)
-
-        return super(Check, cls).from_config(name, config)
 
 
 class deque(collections.deque):

--- a/lighthouse/discovery.py
+++ b/lighthouse/discovery.py
@@ -66,14 +66,14 @@ class Discovery(Pluggable):
         """
         raise NotImplementedError
 
-    def report_up(self, service):
+    def report_up(self, service, port):
         """
         This method is used to denote that the given service present on the
         current machine should be considered up and available.
         """
         raise NotImplementedError
 
-    def report_down(self, service):
+    def report_down(self, service, port):
         """
         This method is used to denote that the given service present on the
         current machine should be considered down and unavailable.

--- a/lighthouse/node.py
+++ b/lighthouse/node.py
@@ -32,7 +32,7 @@ class Node(object):
         return self.host + ":" + str(self.port)
 
     @classmethod
-    def current(cls, service):
+    def current(cls, service, port):
         """
         Returns a Node instance representing the current service node.
 
@@ -43,7 +43,7 @@ class Node(object):
         return cls(
             host=host,
             ip=socket.gethostbyname(host),
-            port=service.port,
+            port=port,
             metadata=service.metadata
         )
 

--- a/lighthouse/service.py
+++ b/lighthouse/service.py
@@ -1,3 +1,4 @@
+import collections
 import logging
 
 import six
@@ -21,12 +22,16 @@ class Service(Configurable):
 
     def __init__(self):
         self.host = None
-        self.port = None
-        self.discoery = None
+        self.ports = set()
 
-        self.checks = {}
+        self.configured_ports = None
+
+        self.discovery = None
+
+        self.checks = collections.defaultdict(dict)
         self.check_interval = None
-        self.is_up = None
+
+        self.is_up = collections.defaultdict(lambda: None)
 
         self.metadata = {}
 
@@ -36,22 +41,33 @@ class Service(Configurable):
         Runs a check on the given config to make sure that `host`, `port`,
         `checks`, `discovery` and an interval for the checks is defined.
         """
-        if "port" not in config:
-            raise ValueError("Port not defined.")
+        if "discovery" not in config:
+            raise ValueError("No discovery method defined.")
+
+        if not any([item in config for item in ["port", "ports"]]):
+            raise ValueError("No port(s) defined.")
+
+        cls.validate_check_configs(config)
+
+    @classmethod
+    def validate_check_configs(cls, config):
+        """
+        Config validation specific to the health check options.
+
+        Verifies that checks are defined along with an interval, and calls
+        out to the `Check` class to make sure each individual check's config
+        is valid.
+        """
         if "checks" not in config:
             raise ValueError("No checks defined.")
         if "interval" not in config["checks"]:
             raise ValueError("No check interval defined.")
-        if "discovery" not in config:
-            raise ValueError("No discovery method defined.")
 
         for check_name, check_config in six.iteritems(config["checks"]):
             if check_name == "interval":
                 continue
 
-            Check.from_config(
-                check_name, config["host"], config["port"], check_config
-            )
+            Check.from_config(check_name, check_config)
 
     def apply_config(self, config):
         """
@@ -64,28 +80,97 @@ class Service(Configurable):
         is logged and the check skipped.
         """
         self.host = config.get("host", "127.0.0.1")
-        self.port = config["port"]
+
+        self.configured_ports = config.get("ports", [config.get("port")])
+
         self.discovery = config["discovery"]
 
         self.metadata = config.get("metadata", {})
 
+        self.update_ports()
+
         self.check_interval = config["checks"]["interval"]
 
-        for check_name, check_config in six.iteritems(config["checks"]):
+        self.update_checks(config["checks"])
+
+    def update_ports(self):
+        """
+        Sets the `ports` attribute to the set of valid port values set in
+        the configuration.
+        """
+        ports = set()
+
+        for port in self.configured_ports:
+            try:
+                ports.add(int(port))
+            except ValueError:
+                logger.error("Invalid port value: %s", port)
+                continue
+
+        self.ports = ports
+
+    def update_checks(self, check_configs):
+        """
+        Maintains the values in the `checks` attribute's dictionary.  Each
+        key in the dictionary is a port, and each value is a nested dictionary
+        mapping each check's name to the Check instance.
+
+        This method makes sure the attribute reflects all of the properly
+        configured checks and ports.  Removing no-longer-configured ports
+        is left to the `run_checks` method.
+        """
+        for check_name, check_config in six.iteritems(check_configs):
             if check_name == "interval":
                 continue
 
-            try:
-                if check_name in self.checks:
-                    self.checks[check_name].validate_config(check_config)
-                    self.checks[check_name].apply_config(check_config)
-                else:
-                    self.checks[check_name] = Check.from_config(
-                        check_name, self.host, self.port, check_config
+            for port in self.ports:
+                try:
+                    check = Check.from_config(check_name, check_config)
+                    check.host = self.host
+                    check.port = port
+                    self.checks[port][check_name] = check
+                except ValueError as e:
+                    logger.error(
+                        "Error when configuring check '%s' for service %s: %s",
+                        check_name, self.name, str(e)
                     )
-            except ValueError as e:
-                logger.error(
-                    "Error when configuring check '%s' for service '%s': %s",
-                    check_name, self.name, str(e)
-                )
-                continue
+                    continue
+
+    def run_checks(self):
+        """
+        Iterates over the configured ports and runs the checks on each one.
+
+        Returns a two-element tuple: the first is the set of ports that
+        transitioned from down to up, the second is the set of ports that
+        transitioned from up to down.
+
+        Also handles the case where a check for a since-removed port is run,
+        marking the port as down regardless of the check's result and removing
+        the check(s) for the port.
+        """
+        came_up = set()
+        went_down = set()
+
+        for port in self.ports:
+            checks = self.checks[port].values()
+
+            if not checks:
+                logger.warn("No checks defined for self: %s", self.name)
+
+            for check in checks:
+                check.run()
+
+            checks_pass = all([check.passing for check in checks])
+
+            if self.is_up[port] in (False, None) and checks_pass:
+                came_up.add(port)
+                self.is_up[port] = True
+            elif self.is_up[port] in (True, None) and not checks_pass:
+                went_down.add(port)
+                self.is_up[port] = False
+
+        for unused_port in set(self.checks.keys()) - self.ports:
+            went_down.add(unused_port)
+            del self.checks[unused_port]
+
+        return came_up, went_down

--- a/lighthouse/zookeeper.py
+++ b/lighthouse/zookeeper.py
@@ -239,7 +239,7 @@ class ZookeeperDiscovery(Discovery):
 
         self.watched_clusters.discard(cluster)
 
-    def report_up(self, service):
+    def report_up(self, service, port):
         """
         Report the given service's present node as up by creating/updating
         its respective znode in Zookeeper and setting the znode's data to
@@ -252,7 +252,7 @@ class ZookeeperDiscovery(Discovery):
             logger.warn("Not connected to zookeeper, cannot save znode.")
             return
 
-        node = Node.current(service)
+        node = Node.current(service, port)
 
         path = self.path_of(service, node)
         data = node.serialize().encode()
@@ -267,7 +267,7 @@ class ZookeeperDiscovery(Discovery):
                 ephemeral=True, makepath=True
             )
 
-    def report_down(self, service):
+    def report_down(self, service, port):
         """
         Reports the given service's present node as down by deleting the
         node's znode in Zookeeper if the znode is present.
@@ -279,7 +279,7 @@ class ZookeeperDiscovery(Discovery):
             logger.warn("Not connected to zookeeper, cannot delete znode.")
             return
 
-        node = Node.current(service)
+        node = Node.current(service, port)
 
         path = self.path_of(service, node)
         try:

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,14 @@ setup(
     ],
     extras_require={
         "redis": [],
+        "docker": [
+            "docker-py",
+        ],
     },
     entry_points={
         "console_scripts": [
             "lighthouse-reporter = lighthouse.scripts.reporter:run",
-            "lighthouse-writer = lighthouse.scripts.writer:run"
+            "lighthouse-writer = lighthouse.scripts.writer:run",
         ],
         "lighthouse.balancers": [
             "haproxy = lighthouse.haproxy.balancer:HAProxy",

--- a/tests/check_tests.py
+++ b/tests/check_tests.py
@@ -32,7 +32,7 @@ class BaseCheckTests(unittest.TestCase):
         self.assertRaises(
             NotImplementedError,
             check.apply_check_config,
-            {"host": "serv01", "port": 1234, "rise": 1, "fall": 1}
+            {"rise": 1, "fall": 1}
         )
 
     @patch.object(Check, "validate_config", Mock())
@@ -56,38 +56,11 @@ class BaseCheckTests(unittest.TestCase):
     @patch.object(Check, "validate_check_config")
     def test_validate_config(self, check_validate):
         Check.validate_config(
-            {"host": "serv03", "port": 1235, "rise": 2, "fall": 3}
+            {"rise": 2, "fall": 3}
         )
 
         check_validate.assert_called_once_with(
-            {"host": "serv03", "port": 1235, "rise": 2, "fall": 3}
-        )
-
-    @patch.object(Check, "apply_check_config", Mock())
-    @patch.object(Check, "validate_check_config")
-    def test_validate_config_with_no_host(self, check_validate):
-        self.assertRaises(
-            ValueError,
-            Check.validate_config,
-            {"port": 1234, "rise": 1, "fall": 1}
-        )
-
-    @patch.object(Check, "apply_check_config", Mock())
-    @patch.object(Check, "validate_check_config")
-    def test_validate_config_with_no_port(self, check_validate):
-        self.assertRaises(
-            ValueError,
-            Check.validate_config,
-            {"host": "serv03", "rise": 1, "fall": 1}
-        )
-
-    @patch.object(Check, "apply_check_config", Mock())
-    @patch.object(Check, "validate_check_config")
-    def test_validate_config_with_invalid_port(self, check_validate):
-        self.assertRaises(
-            ValueError,
-            Check.validate_config,
-            {"host": "serv03", "port": "foo", "rise": 1, "fall": 1}
+            {"rise": 2, "fall": 3}
         )
 
     @patch.object(Check, "apply_check_config", Mock())
@@ -96,7 +69,7 @@ class BaseCheckTests(unittest.TestCase):
         self.assertRaises(
             ValueError,
             Check.validate_config,
-            {"host": "serv03", "port": 1234, "fall": 1}
+            {"fall": 1}
         )
 
     @patch.object(Check, "apply_check_config", Mock())
@@ -105,26 +78,14 @@ class BaseCheckTests(unittest.TestCase):
         self.assertRaises(
             ValueError,
             Check.validate_config,
-            {"host": "serv03", "port": 1234, "rise": 1}
+            {"rise": 1}
         )
-
-    @patch.object(Check, "apply_check_config", Mock())
-    @patch.object(Check, "validate_config")
-    def test_apply_config_coerces_port(self, validate):
-        check = Check()
-        check.apply_config(
-            {"host": "serv01", "port": "1234", "rise": 3, "fall": 1}
-        )
-
-        self.assertEqual(check.port, 1234)
 
     @patch.object(Check, "apply_check_config", Mock())
     @patch.object(Check, "validate_config")
     def test_results_size_is_greater_of_rise_or_fall(self, validate):
         check = Check()
-        check.apply_config(
-            {"host": "serv01", "port": 1234, "rise": 3, "fall": 1}
-        )
+        check.apply_config({"rise": 3, "fall": 1})
 
         self.assertEqual(len(check.results), 3)
         assert not any(list(check.results))
@@ -141,9 +102,7 @@ class BaseCheckTests(unittest.TestCase):
         perform.side_effect = get_next_fake_result
 
         check = Check()
-        check.apply_config(
-            {"host": "serv01", "port": 1234, "rise": 3, "fall": 1}
-        )
+        check.apply_config({"rise": 3, "fall": 1})
 
         check.run()
 
@@ -188,9 +147,7 @@ class BaseCheckTests(unittest.TestCase):
         perform.return_value = True
 
         check = Check()
-        check.apply_config(
-            {"host": "serv01", "port": 1234, "rise": 2, "fall": 1}
-        )
+        check.apply_config({"rise": 2, "fall": 1})
 
         self.assertEqual(check.passing, False)
 
@@ -214,9 +171,7 @@ class BaseCheckTests(unittest.TestCase):
         perform.side_effect = get_next_fake_result
 
         check = Check()
-        check.apply_config(
-            {"host": "serv01", "port": 1234, "rise": 2, "fall": 2}
-        )
+        check.apply_config({"rise": 2, "fall": 2})
 
         check.run()
         check.run()
@@ -237,7 +192,7 @@ class BaseCheckTests(unittest.TestCase):
     def test_apply_config_with_higher_fall_count(self, perform):
         perform.return_value = True
 
-        config = {"host": "serv01", "port": 1234, "rise": 2, "fall": 2}
+        config = {"rise": 2, "fall": 2}
 
         check = Check()
         check.apply_config(config)
@@ -271,7 +226,7 @@ class BaseCheckTests(unittest.TestCase):
     def test_apply_config_with_lower_rise_count(self, perform):
         perform.return_value = True
 
-        config = {"host": "serv01", "port": 1234, "rise": 3, "fall": 2}
+        config = {"rise": 3, "fall": 2}
 
         check = Check()
         check.apply_config(config)
@@ -305,7 +260,7 @@ class BaseCheckTests(unittest.TestCase):
     def test_apply_config_no_change_in_max_count(self, perform):
         perform.return_value = True
 
-        config = {"host": "serv01", "port": 1234, "rise": 3, "fall": 2}
+        config = {"rise": 3, "fall": 2}
 
         check = Check()
         check.apply_config(config)
@@ -341,9 +296,7 @@ class BaseCheckTests(unittest.TestCase):
         perform.side_effect = ValueError
 
         check = Check()
-        check.apply_config(
-            {"host": "serv01", "port": 1234, "rise": 2, "fall": 2}
-        )
+        check.apply_config({"rise": 2, "fall": 2})
 
         self.assertEqual(
             list(check.results),
@@ -366,13 +319,11 @@ class BaseCheckTests(unittest.TestCase):
             "fakecheck": fake_check_class
         }
 
-        result = Check.from_config("fakecheck", "serv03", 8001, {"foo": "bar"})
+        result = Check.from_config("fakecheck", {"foo": "bar"})
 
         self.assertEqual(result, fake_check_class.return_value)
 
-        result.apply_config.assert_called_once_with(
-            {"host": "serv03", "port": 8001, "foo": "bar"}
-        )
+        result.apply_config.assert_called_once_with({"foo": "bar"})
 
     @patch.object(Check, "apply_check_config", Mock())
     @patch.object(Check, "validate_config", Mock())
@@ -384,5 +335,5 @@ class BaseCheckTests(unittest.TestCase):
 
         self.assertRaises(
             ValueError,
-            Check.from_config, "othercheck", "serv01", 8888, {"foo": "bar"}
+            Check.from_config, "othercheck", {"foo": "bar"}
         )

--- a/tests/checks/http_tests.py
+++ b/tests/checks/http_tests.py
@@ -29,12 +29,9 @@ class HTTPCheckTests(unittest.TestCase):
         connection.getresponse.return_value.status = 200
 
         check = HTTPCheck()
-        check.apply_config(
-            {
-                "host": "localhost", "port": 9999, "uri": "/foo",
-                "rise": 1, "fall": 1
-            }
-        )
+        check.apply_config({"uri": "/foo", "rise": 1, "fall": 1})
+        check.host = "localhost"
+        check.port = 9999
 
         check.perform()
 
@@ -52,11 +49,13 @@ class HTTPCheckTests(unittest.TestCase):
         check = HTTPCheck()
         check.apply_config(
             {
-                "host": "localhost", "port": 9999, "uri": "/foo",
+                "uri": "/foo",
                 "method": "POST",
                 "rise": 1, "fall": 1
             }
         )
+        check.host = "localhost"
+        check.port = 9999
 
         check.perform()
 
@@ -69,11 +68,13 @@ class HTTPCheckTests(unittest.TestCase):
         check = HTTPCheck()
         check.apply_config(
             {
-                "host": "localhost", "port": 9999, "uri": "/foo",
+                "uri": "/foo",
                 "https": True,
                 "rise": 1, "fall": 1
             }
         )
+        check.host = "localhost"
+        check.port = 9999
 
         check.perform()
 
@@ -84,12 +85,9 @@ class HTTPCheckTests(unittest.TestCase):
         connection.getresponse.return_value.status = 200
 
         check = HTTPCheck()
-        check.apply_config(
-            {
-                "host": "localhost", "port": 9999, "uri": "/foo",
-                "rise": 1, "fall": 1
-            }
-        )
+        check.apply_config({"uri": "/foo", "rise": 1, "fall": 1})
+        check.host = "localhost"
+        check.port = 9999
 
         self.assertEqual(check.perform(), True)
 
@@ -98,12 +96,9 @@ class HTTPCheckTests(unittest.TestCase):
         connection.getresponse.return_value.status = 300
 
         check = HTTPCheck()
-        check.apply_config(
-            {
-                "host": "localhost", "port": 9999, "uri": "/foo",
-                "rise": 1, "fall": 1
-            }
-        )
+        check.apply_config({"uri": "/foo", "rise": 1, "fall": 1})
+        check.host = "localhost"
+        check.port = 9999
 
         self.assertEqual(check.perform(), False)
 
@@ -112,12 +107,9 @@ class HTTPCheckTests(unittest.TestCase):
         connection.getresponse.return_value.status = 500
 
         check = HTTPCheck()
-        check.apply_config(
-            {
-                "host": "localhost", "port": 9999, "uri": "/foo",
-                "rise": 1, "fall": 1
-            }
-        )
+        check.apply_config({"uri": "/foo", "rise": 1, "fall": 1})
+        check.host = "localhost"
+        check.port = 9999
 
         self.assertEqual(check.perform(), False)
 
@@ -126,11 +118,8 @@ class HTTPCheckTests(unittest.TestCase):
         connection.getresponse.return_value.status = 404
 
         check = HTTPCheck()
-        check.apply_config(
-            {
-                "host": "localhost", "port": 9999, "uri": "/foo",
-                "rise": 1, "fall": 1
-            }
-        )
+        check.apply_config({"uri": "/foo", "rise": 1, "fall": 1})
+        check.host = "localhost"
+        check.port = 9999
 
         self.assertEqual(check.perform(), False)

--- a/tests/discovery_tests.py
+++ b/tests/discovery_tests.py
@@ -64,7 +64,7 @@ class DiscoveryTests(unittest.TestCase):
 
         self.assertRaises(
             NotImplementedError,
-            discovery.report_up, Mock()
+            discovery.report_up, Mock(), 8000
         )
 
     def test_report_down_required(self):
@@ -72,7 +72,7 @@ class DiscoveryTests(unittest.TestCase):
 
         self.assertRaises(
             NotImplementedError,
-            discovery.report_down, Mock()
+            discovery.report_down, Mock(), 8000
         )
 
     def test_disconnect_required(self):

--- a/tests/zookeeper_tests.py
+++ b/tests/zookeeper_tests.py
@@ -208,7 +208,7 @@ class ZookeeperTests(unittest.TestCase):
 
         zk.connected = False
 
-        zk.report_up(Mock())
+        zk.report_up(Mock(), 8888)
 
         self.assertEqual(zk.client.set.called, False)
 
@@ -226,10 +226,10 @@ class ZookeeperTests(unittest.TestCase):
         )
         zk.connect()
 
-        service = Mock(port="6379", metadata={"type": "master"})
+        service = Mock(metadata={"type": "master"})
         service.name = "webcache"
 
-        zk.report_up(service)
+        zk.report_up(service, 6379)
 
         set_args, set_kwargs = zk.client.set.call_args
 
@@ -245,7 +245,7 @@ class ZookeeperTests(unittest.TestCase):
             {
                 "host": "redis1.int.local",
                 "ip": "10.0.1.8",
-                "port": "6379",
+                "port": 6379,
                 "metadata": {"type": "master"},
                 "peer": {
                     "port": 1024,
@@ -271,10 +271,10 @@ class ZookeeperTests(unittest.TestCase):
 
         zk.client.set.side_effect = exceptions.NoNodeError
 
-        service = Mock(port="6379", metadata={})
+        service = Mock(metadata={})
         service.name = "webcache"
 
-        zk.report_up(service)
+        zk.report_up(service, 6379)
 
         self.assertEqual(zk.client.create.call_count, 1)
         create_args, create_kwargs = zk.client.create.call_args
@@ -296,7 +296,7 @@ class ZookeeperTests(unittest.TestCase):
             {
                 "host": "redis1.int.local",
                 "ip": "10.0.1.8",
-                "port": "6379",
+                "port": 6379,
                 "metadata": {},
                 "peer": {
                     "port": 1024,
@@ -315,10 +315,10 @@ class ZookeeperTests(unittest.TestCase):
 
         zk.connected = False
 
-        service = Mock(host="redis1", port="6379")
+        service = Mock(host="redis1")
         service.name = "webcache"
 
-        zk.report_down(service)
+        zk.report_down(service, 6379)
 
         self.assertEqual(zk.client.delete.called, False)
 
@@ -331,10 +331,10 @@ class ZookeeperTests(unittest.TestCase):
         )
         zk.connect()
 
-        service = Mock(port="5678")
+        service = Mock()
         service.name = "userdb"
 
-        zk.report_down(service)
+        zk.report_down(service, 5678)
 
         zk.client.delete.assert_called_once_with(
             "/lighthouse/userdb/pg01.int.local:5678"
@@ -349,10 +349,10 @@ class ZookeeperTests(unittest.TestCase):
 
         zk.client.delete.side_effect = exceptions.NoNodeError
 
-        service = Mock(host="redis1", port="6379")
+        service = Mock(host="redis1")
         service.name = "webcache"
 
-        zk.report_down(service)
+        zk.report_down(service, 6379)
 
     @patch("lighthouse.zookeeper.threading")
     def test_start_watching(self, mock_threading, mock_client):


### PR DESCRIPTION
Service configurations can now provide a list of ports rather than
having to have a separate config file for each instance of a service on
a given machine.