### PR TITLE
Make sure to sync files whenever clusters change.

### DIFF
--- a/lighthouse/writer.py
+++ b/lighthouse/writer.py
@@ -36,7 +36,7 @@ class Writer(ConfigWatcher):
         Runs the main thread of the writer ConfigWatcher.
 
         This merely launches a separate thread for the config-file-updating
-        loop and waits on the `shutdown` event.
+        loop and waits on thwe `shutdown` event.
         """
         logger.info("Running writer.")
 
@@ -111,12 +111,16 @@ class Writer(ConfigWatcher):
 
             discovery.start_watching(cluster)
 
+        self.nodes_updated.set()
+
     def on_discovery_remove(self, name):
         """
         When a Discovery is removed we must make sure to call its `stop()`
         method to close any connections or do any clean up.
         """
         self.configurables[Discovery][name].stop()
+
+        self.nodes_updated.set()
 
     def on_cluster_add(self, cluster):
         """
@@ -130,6 +134,8 @@ class Writer(ConfigWatcher):
         self.configurables[Discovery][cluster.discovery].start_watching(
             cluster
         )
+
+        self.nodes_updated.set()
 
     def on_cluster_update(self, name, new_config):
         """
@@ -184,6 +190,8 @@ class Writer(ConfigWatcher):
             self.configurables[Discovery][discovery_name].stop_watching(
                 self.configurables[Cluster][name]
             )
+
+        self.nodes_updated.set()
 
     def wind_down(self):
         """

--- a/tests/writer_tests.py
+++ b/tests/writer_tests.py
@@ -264,3 +264,41 @@ class WriterTests(unittest.TestCase):
         writer.remove_configurable(Discovery, "existing")
 
         discovery.stop.assert_called_once_with()
+
+    def test_add_cluster_triggers_node_update(self):
+        writer = Writer("/etc/lighthouse")
+        writer.nodes_updated = Mock()
+        writer.configurables[Discovery]["zk"] = Mock()
+
+        writer.add_configurable(Cluster, "webapp", Mock(discovery="zk"))
+
+        writer.nodes_updated.set.assert_called_once_with()
+
+    def test_add_discovery_triggers_node_update(self):
+        writer = Writer("/etc/lighthouse")
+        writer.nodes_updated = Mock()
+
+        writer.add_configurable(Discovery, "riak", Mock())
+
+        writer.nodes_updated.set.assert_called_once_with()
+
+    def test_remove_discovery_triggers_node_update(self):
+        writer = Writer("/etc/lighthouse")
+        writer.nodes_updated = Mock()
+        writer.configurables[Discovery]["zk"] = Mock()
+
+        writer.remove_configurable(Discovery, "zk")
+
+        writer.nodes_updated.set.assert_called_once_with()
+
+    def test_remove_cluster_triggers_node_update(self):
+        writer = Writer("/etc/lighthouse")
+        writer.nodes_updated = Mock()
+        writer.configurables = {
+            Discovery: {"zk": Mock()},
+            Cluster: {"webapp": Mock(discovery="zk")}
+        }
+
+        writer.remove_configurable(Cluster, "webapp")
+
+        writer.nodes_updated.set.assert_called_once_with()


### PR DESCRIPTION
Without these nodes_updated.set() calls, there could be a race condition
where the Balancer is added before any Cluster or Discovery and
sync_files() spits out a blank config.  Once the Cluster or Discovery
were added the files remained unsynced.