### PR TITLE
Refactor concurrency

### DIFF
--- a/lighthouse/events.py
+++ b/lighthouse/events.py
@@ -8,7 +8,7 @@ import six
 logger = logging.getLogger(__name__)
 
 
-def wait_on_any(*events):
+def wait_on_any(*events, **kwargs):
     """
     Helper method for waiting for any of the given threading events to be
     set.
@@ -18,7 +18,11 @@ def wait_on_any(*events):
     so that their `set()` and `clear()` methods fire a callback we can use
     to determine how a composite event should react.
     """
+    timeout = kwargs.get("timeout")
     composite_event = threading.Event()
+
+    if any([event.is_set() for event in events]):
+        return
 
     def on_change():
         if any([event.is_set() for event in events]):
@@ -38,7 +42,7 @@ def wait_on_any(*events):
         event.set = patch(event.set)
         event.clear = patch(event.clear)
 
-    wait_on_event(composite_event)
+    wait_on_event(composite_event, timeout=timeout)
 
 
 def wait_on_event(event, timeout=None):

--- a/lighthouse/haproxy/config.py
+++ b/lighthouse/haproxy/config.py
@@ -83,7 +83,7 @@ class HAProxyConfig(object):
                 Section("Listener for stats web interface", self.stats_stanza)
             )
 
-        return "\n\n\n".join([str(section) for section in sections])
+        return "\n\n\n".join([str(section) for section in sections]) + "\n"
 
     def get_meta_clusters(self, clusters):
         """

--- a/lighthouse/service.py
+++ b/lighthouse/service.py
@@ -38,8 +38,8 @@ class Service(Configurable):
     @classmethod
     def validate_config(cls, config):
         """
-        Runs a check on the given config to make sure that `host`, `port`,
-        `checks`, `discovery` and an interval for the checks is defined.
+        Runs a check on the given config to make sure that `port`/`ports` and
+        `discovery` is defined.
         """
         if "discovery" not in config:
             raise ValueError("No discovery method defined.")
@@ -92,6 +92,15 @@ class Service(Configurable):
         self.check_interval = config["checks"]["interval"]
 
         self.update_checks(config["checks"])
+
+    def reset_status(self):
+        """
+        Sets the up/down status of the service ports to the default state.
+
+        Useful for when the configuration is updated and the checks involved
+        in determining the status might have changed.
+        """
+        self.is_up = collections.defaultdict(lambda: None)
 
     def update_ports(self):
         """

--- a/tests/events_tests.py
+++ b/tests/events_tests.py
@@ -71,3 +71,27 @@ class EventsTests(unittest.TestCase):
         events.wait_on_event(mock_event)
 
         mock_event.wait.assert_called_once_with()
+
+    @patch.object(events, "wait_on_event")
+    def test_wait_on_any_with_timeout(self, wait_on_event):
+        event1 = Mock()
+        event1.is_set.return_value = False
+        event2 = Mock()
+        event2.is_set.return_value = False
+
+        events.wait_on_any(event1, event2, timeout=20)
+
+        _, wait_kwargs = wait_on_event.call_args
+
+        self.assertEqual(wait_kwargs["timeout"], 20)
+
+    @patch.object(events, "wait_on_event")
+    def test_wait_on_any_shortcircuits_if_already_set(self, wait_on_event):
+        event1 = Mock()
+        event1.is_set.return_value = True
+        event2 = Mock()
+        event2.is_set.return_value = False
+
+        events.wait_on_any(event1, event2, timeout=20)
+
+        assert wait_on_event.called is False


### PR DESCRIPTION
The main difference now is that the ConfigWatcher base class now has a
"work_pool" for async jobs as well as a "thread_pool" for long-lived
tasks.

The Zookeeper discovery's start_watching() method is greatly simplified
thanks to this and now relies on kazoo's ChildrenWatch as a decorator
rather than calling it directly in a loop.

The Writer and Reporter classes are also simplified as they no longer
have to worry about when to launch threads.  They *do* have to worry
about the fact that each on_* method will be in a different thread.