### PR TITLE
Logging revamp

### DIFF
--- a/docs/code/logging.rst
+++ b/docs/code/logging.rst
@@ -1,0 +1,9 @@
+Logging
+=======
+
+.. toctree::
+
+   modules/log
+   modules/log.config
+   modules/log.context
+   modules/log.cli

--- a/docs/code/modules/log.cli.rst
+++ b/docs/code/modules/log.cli.rst
@@ -1,0 +1,7 @@
+``lighthouse.log.cli``
+=========================
+
+.. automodule:: lighthouse.log.cli
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/code/modules/log.config.rst
+++ b/docs/code/modules/log.config.rst
@@ -1,0 +1,7 @@
+``lighthouse.log.config``
+=========================
+
+.. automodule:: lighthouse.log.config
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/code/modules/log.context.rst
+++ b/docs/code/modules/log.context.rst
@@ -1,0 +1,7 @@
+``lighthouse.log.context``
+==========================
+
+.. automodule:: lighthouse.log.context
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,7 +5,8 @@ The lighthouse scripts are configured by passing in a root config directory whic
 contains individual YAML_ config files and follows a certain layout::
 
     <config dir>/
-      |____haproxy.yaml
+      |____balancers/
+      |      |____haproxy.yaml
       |____discovery/
       |      |____zookeeper.yaml
       |____clusters/
@@ -22,7 +23,7 @@ There are four types of config file:
 * **balancer**:
 
   Files that configure the locally-running load balancer(s).  These live in the
-  root of the config directory. The project includes a plugin for HAProxy as a
+  ``balancers`` subdirectory. The project includes a plugin for HAProxy as a
   balancer.
 
   :doc:`configuration/haproxy`

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,6 +5,7 @@ The lighthouse scripts are configured by passing in a root config directory whic
 contains individual YAML_ config files and follows a certain layout::
 
     <config dir>/
+      |____logging.yaml
       |____balancers/
       |      |____haproxy.yaml
       |____discovery/
@@ -18,7 +19,14 @@ contains individual YAML_ config files and follows a certain layout::
       |      |____other_service.yaml
 
 
-There are four types of config file:
+There are five types of config file:
+
+* **logging**:
+
+  This file lives at the root of the config directory and its contents are
+  passed to the standard lib `logging.config` module's `dictConfig` function.
+
+  :doc:`configuration/logging`
 
 * **balancer**:
 
@@ -63,6 +71,7 @@ There are four types of config file:
    :hidden:
    :maxdepth: 1
 
+   configuration/logging
    configuration/haproxy
    configuration/zookeeper
    configuration/clusters

--- a/docs/configuration/logging.rst
+++ b/docs/configuration/logging.rst
@@ -1,0 +1,79 @@
+Configuring Logging
+===================
+
+The content of the logging config file is passed along to the standard `logging`
+lib's `dictConfig`_ method.  Lighthouse does not verify the configuration itself,
+but the contents should conform to the `dict config schema` since that's what
+the `logging` system expects.
+
+Lighthouse *does* however provide two helper classes for logging: the
+`CLIHandler`_ and the `ContextFilter`_.
+
+As an example, this file sends logs to stdout with the `CLIHandler` attached, as
+well as to the local syslog system with added "program" context via the
+`ContextFilter`:
+
+`logging.yaml`
+
+.. code-block:: yaml
+
+    version: 1
+    disable_existing_loggers: False
+    filters:
+      context:
+        "()": lighthouse.log.ContextFilter
+    formatters:
+      syslog:
+        format: 'lighthouse: [%(program)s] [%(threadName)s] %(message)s'
+    handlers:
+      cli:
+        class: 'lighthouse.log.cli.CLIHandler'
+        stream: "ext://sys.stdout"
+      syslog:
+        class: 'logging.handlers.SysLogHandler'
+        address: '/dev/log'
+        facility: "local6"
+        filters: ["context"]
+        formatter: 'syslog'
+    root:
+      handlers: ['syslog', 'cli']
+      level: "DEBUG"
+      propagate: true
+
+
+ContextFilter
+~~~~~~~~~~~~~
+
+A simple `logging.Filter` subclass that adds a "program" attribute to any
+`LogRecord`s that pass through it.  For the `lighthouse-writer` script the
+attribute is set to "WRITER", for `lighthouse-reporter` it is set to "REPORTER".
+
+Useful for differentiating log lines between the two scripts.
+
+
+CLIHandler
+~~~~~~~~~~
+
+Handy `logging.StreamHandler` subclass that colors the log lines based on the
+thread the log originated from and the level (e.g. "info", "warning", debug",
+etc.)
+
+Some example lines::
+
+    [2015-09-22 18:52:40 I][MainThread] Adding loggingconfig: 'logging'
+    [2015-09-22 18:52:40 D][MainThread] File created: /Users/william/local-config/balancers/haproxy.yml
+    [2015-09-22 18:52:40 I][MainThread] Adding balancer: 'haproxy'
+    [2015-09-22 18:52:40 I][Thread-3] Updating HAProxy config file.
+    [2015-09-22 18:52:40 D][MainThread] File created: /Users/william/local-config/discovery/zookeeper.yaml
+    [2015-09-22 18:52:40 D][Thread-3] Got HAProxy version: (1, 5, 10)
+    [2015-09-22 18:52:41 I][MainThread] Adding discovery: 'zookeeper'
+    [2015-09-22 18:52:41 D][Thread-3] Got HAProxy version: (1, 5, 10)
+    [2015-09-22 18:52:41 I][Thread-12] Connecting to zookeeper02.oregon.internal:2181
+    [2015-09-22 18:52:41 I][Thread-7] Updating HAProxy config file.
+    [2015-09-22 18:52:41 D][MainThread] File created: /Users/william/local-config/clusters/haproxy-web.yaml
+    [2015-09-22 18:52:41 I][Thread-3] Gracefully restarted HAProxy.
+    [2015-09-22 18:52:41 I][MainThread] Adding cluster: 'haproxy-web'
+
+
+.. _dictConfig: https://docs.python.org/2/library/logging.config.html#logging.config.dictConfig
+.. _`dict config schema`: https://docs.python.org/2/library/logging.config.html#logging-config-dictschema

--- a/docs/source_docs.rst
+++ b/docs/source_docs.rst
@@ -13,3 +13,4 @@ Source Docs
    code/scripts
    code/helpers
    code/redis
+   code/logging

--- a/examples/dockerfiles/Dockerfile.base
+++ b/examples/dockerfiles/Dockerfile.base
@@ -18,6 +18,7 @@ RUN . /opt/venvs/lighthouse/bin/activate; cd /opt/src/lighthouse-*; pip install 
 RUN mkdir -p /var/log/supervisor/lighthouse
 COPY supervisord/lighthouse.conf /etc/supervisord/conf.d/
 
+RUN mkdir -p /etc/lighthouse/balancers
 RUN mkdir -p /etc/lighthouse/clusters
 RUN mkdir -p /etc/lighthouse/discovery
 RUN mkdir -p /etc/lighthouse/services

--- a/examples/dockerfiles/Dockerfile.cache
+++ b/examples/dockerfiles/Dockerfile.cache
@@ -45,7 +45,7 @@ WORKDIR /data
 
 RUN /opt/venvs/lighthouse/bin/pip install redis
 
-COPY configs/haproxy.yaml /etc/lighthouse/
+COPY configs/haproxy.yaml /etc/lighthouse/balancers/
 COPY configs/discovery/zookeeper.yaml /etc/lighthouse/discovery/
 COPY configs/services/cache.yaml /etc/lighthouse/services/
 

--- a/examples/dockerfiles/Dockerfile.client
+++ b/examples/dockerfiles/Dockerfile.client
@@ -2,7 +2,7 @@ FROM lighthouse.examples.base
 
 RUN apt-get install -y curl
 
-COPY configs/haproxy.yaml /etc/lighthouse/
+COPY configs/haproxy.yaml /etc/lighthouse/balancers/
 COPY configs/discovery/zookeeper.yaml /etc/lighthouse/discovery/
 COPY configs/clusters/webapp.yaml /etc/lighthouse/clusters/
 COPY configs/clusters/api_widgets.yaml /etc/lighthouse/clusters/

--- a/examples/dockerfiles/Dockerfile.multiapp
+++ b/examples/dockerfiles/Dockerfile.multiapp
@@ -1,6 +1,6 @@
 FROM lighthouse.examples.base
 
-COPY configs/haproxy.yaml /etc/lighthouse/
+COPY configs/haproxy.yaml /etc/lighthouse/balancers/
 COPY configs/discovery/zookeeper.yaml /etc/lighthouse/discovery/
 COPY configs/clusters/cache.yaml /etc/lighthouse/clusters/
 COPY configs/services/multiapp.yaml /etc/lighthouse/services/

--- a/examples/dockerfiles/Dockerfile.proxy
+++ b/examples/dockerfiles/Dockerfile.proxy
@@ -1,6 +1,6 @@
 FROM lighthouse.examples.base
 
-COPY configs/haproxy-proxies.yaml /etc/lighthouse/haproxy.yaml
+COPY configs/haproxy-proxies.yaml /etc/lighthouse/balancers/haproxy.yaml
 COPY configs/discovery/zookeeper.yaml /etc/lighthouse/discovery/
 COPY configs/services/partner-proxy.yaml /etc/lighthouse/services/
 

--- a/examples/dockerfiles/Dockerfile.sprockets
+++ b/examples/dockerfiles/Dockerfile.sprockets
@@ -1,6 +1,6 @@
 FROM lighthouse.examples.base
 
-COPY configs/haproxy.yaml /etc/lighthouse/
+COPY configs/haproxy.yaml /etc/lighthouse/balancers/
 COPY configs/discovery/zookeeper.yaml /etc/lighthouse/discovery/
 COPY configs/clusters/cache.yaml /etc/lighthouse/clusters/
 COPY configs/clusters/proxy.yaml /etc/lighthouse/clusters/

--- a/examples/dockerfiles/Dockerfile.webapp
+++ b/examples/dockerfiles/Dockerfile.webapp
@@ -1,6 +1,6 @@
 FROM lighthouse.examples.base
 
-COPY configs/haproxy.yaml /etc/lighthouse/
+COPY configs/haproxy.yaml /etc/lighthouse/balancers/
 COPY configs/discovery/zookeeper.yaml /etc/lighthouse/discovery/
 COPY configs/clusters/cache.yaml /etc/lighthouse/clusters/
 COPY configs/services/webapp.yaml /etc/lighthouse/services/

--- a/examples/dockerfiles/Dockerfile.widgets
+++ b/examples/dockerfiles/Dockerfile.widgets
@@ -1,6 +1,6 @@
 FROM lighthouse.examples.base
 
-COPY configs/haproxy.yaml /etc/lighthouse/
+COPY configs/haproxy.yaml /etc/lighthouse/balancers/
 COPY configs/discovery/zookeeper.yaml /etc/lighthouse/discovery/
 COPY configs/clusters/cache.yaml /etc/lighthouse/clusters/
 COPY configs/services/api_widgets.yaml /etc/lighthouse/services/

--- a/lighthouse/balancer.py
+++ b/lighthouse/balancer.py
@@ -18,6 +18,7 @@ class Balancer(Pluggable):
     called whenever an update to the topography of nodes happens.
     """
 
+    config_subdirectory = "balancers"
     entry_point = "lighthouse.balancers"
 
     def sync_file(self, clusters):

--- a/lighthouse/configs/handler.py
+++ b/lighthouse/configs/handler.py
@@ -19,7 +19,7 @@ class ConfigFileChangeHandler(events.PatternMatchingEventHandler):
     When an event comes in the proper callback is fired with processed inputs.
     """
 
-    patterns = ("*.yaml")
+    patterns = ("*.yaml", "*.yml")
 
     def __init__(
         self, target_class, on_add, on_update, on_delete,
@@ -36,7 +36,11 @@ class ConfigFileChangeHandler(events.PatternMatchingEventHandler):
         """
         Helper method for determining the basename of the affected file.
         """
-        return os.path.basename(event.src_path).replace(".yaml", "")
+        name = os.path.basename(event.src_path)
+        name = name.replace(".yaml", "")
+        name = name.replace(".yml", "")
+
+        return name
 
     def on_created(self, event):
         """

--- a/lighthouse/configs/handler.py
+++ b/lighthouse/configs/handler.py
@@ -68,6 +68,9 @@ class ConfigFileChangeHandler(events.PatternMatchingEventHandler):
             )
             return
 
+        if not result:
+            return
+
         self.on_add(self.target_class, name, result)
 
     def on_modified(self, event):

--- a/lighthouse/configs/monitor.py
+++ b/lighthouse/configs/monitor.py
@@ -44,7 +44,9 @@ class ConfigFileMonitor(object):
                 continue
             if (
                 not self.target_class.config_subdirectory
-                and not file_name.endswith(".yaml")
+                and not (
+                    file_name.endswith(".yaml") or file_name.endswith(".yml")
+                )
             ):
                 continue
 

--- a/lighthouse/log/__init__.py
+++ b/lighthouse/log/__init__.py
@@ -1,26 +1,13 @@
 import logging
 
-from .cli import CLIHandler
 from .context import ContextFilter
-from .config import load_yaml, load_json, load_ini
 
 
-def setup(program, config_file=None):
+def setup(program):
     """
-    Simple function that attaches the CLIHandler to the root logger.
+    Simple function that sets the program on the ContextFilter and returns
+    the root logger.
     """
-    if not config_file:
-        logger = logging.getLogger()
-        logger.addHandler(CLIHandler())
-        return logger
-
-    if config_file.endswith(".yaml") or config_file.endswith(".yml"):
-        load_yaml(config_file)
-    elif config_file.endswith(".json"):
-        load_json(config_file)
-    else:
-        load_ini(config_file)
-
     ContextFilter.program = program
 
     return logging.getLogger()

--- a/lighthouse/log/config.py
+++ b/lighthouse/log/config.py
@@ -1,42 +1,49 @@
-import json
 import logging
 import logging.config
 
-import yaml
+from lighthouse.configurable import Configurable
 
 
-def load_yaml(filename):
+log = logging.getLogger(__name__)
+
+
+class Logging(Configurable):
     """
-    Loads a logging config file in YAML.
+    Simple `Configurable` subclass that allows for runtime configuration of
+    python's logging infrastructure.
 
-    Treats the content of the YAML file as a dictConfig.
+    Since python provides a handy `dictConfig` function and our system already
+    provides the watched file contents as dicts the work here is tiny.
     """
-    try:
-        content = yaml.load(open(filename))
-    except Exception:
-        logging.exception("Error loading log config YAML file '%s'", filename)
-        return
 
-    logging.config.dictConfig(content)
+    name = "logging"
 
+    @classmethod
+    def from_config(cls, name, config):
+        """
+        Override of the base `from_config()` method that returns `None` if
+        the name of the config file isn't "logging".
 
-def load_json(filename):
-    """
-    Loads a logging config file in JSON.
+        We do this in case this `Configurable` subclass winds up sharing the
+        root of the config directory with other subclasses.
+        """
+        if name != cls.name:
+            return
 
-    Treats the content of the JSON file as a dictConfig.
-    """
-    try:
-        content = json.load(open(filename))
-    except Exception:
-        logging.exception("Error loading log config JSON file '%s'", filename)
-        return
+        return super(Logging, cls).from_config(name, config)
 
-    logging.config.dictConfig(content)
+    @classmethod
+    def validate_config(cls, config):
+        """
+        The validation of a logging config is a no-op at this time, the call
+        to dictConfig() when the config is applied will do the validation
+        for us.
+        """
+        pass
 
-
-def load_ini(filename):
-    """
-    Loads a standard logging ini config file.
-    """
-    logging.config.fileConfig(filename)
+    def apply_config(self, config):
+        """
+        Simple application of the given config via a call to the `logging`
+        module's `dictConfig()` method.
+        """
+        logging.config.dictConfig(config)

--- a/lighthouse/log/context.py
+++ b/lighthouse/log/context.py
@@ -2,9 +2,19 @@ import logging
 
 
 class ContextFilter(logging.Filter):
+    """
+    Simple `logging.Filter` subclass that adds a `program` attribute to
+    each `LogRecord`.
+
+    The attribute's value comes from the "program" class attribute.
+    """
 
     program = None
 
     def filter(self, record):
+        """
+        Sets the `program` attribute on the record.  Always returns `True` as
+        we're not actually filtering any records, just enhancing them.
+        """
         record.program = self.program
         return True

--- a/lighthouse/reporter.py
+++ b/lighthouse/reporter.py
@@ -1,6 +1,7 @@
 import logging
 
 from .configs.watcher import ConfigWatcher
+from .log.config import Logging
 from .discovery import Discovery
 from .service import Service
 from .events import wait_on_event
@@ -19,7 +20,7 @@ class Reporter(ConfigWatcher):
     service's chosen discovery method.
     """
 
-    watched_configurables = (Discovery, Service)
+    watched_configurables = (Logging, Discovery, Service)
 
     def on_discovery_add(self, discovery):
         """

--- a/lighthouse/scripts/reporter.py
+++ b/lighthouse/scripts/reporter.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 
 from lighthouse import log, reporter
 
@@ -12,25 +11,12 @@ parser.add_argument(
     "config_dir", type=str,
     help="The directory where config files are stored."
 )
-parser.add_argument(
-    "-d", "--debug", action="store_true", default=False,
-    help="Turns on debugging output."
-)
-parser.add_argument(
-    "-l", "--log-config", type=str,
-    help="Config file for the logging system."
-)
 
 
 def run():
     args = parser.parse_args()
 
-    logger = log.setup("REPORTER", args.log_config)
-
-    if args.debug:
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
+    log.setup("REPORTER")
 
     r = reporter.Reporter(args.config_dir)
 

--- a/lighthouse/scripts/writer.py
+++ b/lighthouse/scripts/writer.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 
 from lighthouse import log, writer
 
@@ -12,25 +11,12 @@ parser.add_argument(
     "config_dir", type=str,
     help="The directory where config files are stored."
 )
-parser.add_argument(
-    "-d", "--debug", action="store_true", default=False,
-    help="Turns on debugging output."
-)
-parser.add_argument(
-    "-l", "--log-config", type=str,
-    help="Config file for the logging system."
-)
 
 
 def run():
     args = parser.parse_args()
 
-    logger = log.setup("WRITER", args.log_config)
-
-    if args.debug:
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
+    log.setup("WRITER")
 
     w = writer.Writer(args.config_dir)
 

--- a/lighthouse/writer.py
+++ b/lighthouse/writer.py
@@ -1,6 +1,7 @@
 import logging
 
 from .configs.watcher import ConfigWatcher
+from .log.config import Logging
 from .balancer import Balancer
 from .cluster import Cluster
 from .discovery import Discovery
@@ -22,7 +23,7 @@ class Writer(ConfigWatcher):
     config file contents with the updated clusters.
     """
 
-    watched_configurables = (Balancer, Discovery, Cluster)
+    watched_configurables = (Logging, Balancer, Discovery, Cluster)
 
     def sync_balancer_files(self):
         """

--- a/tests/configs/handler_tests.py
+++ b/tests/configs/handler_tests.py
@@ -174,6 +174,31 @@ class ConfigChangeHandlerTests(unittest.TestCase):
         assert on_add.called is False
         assert on_delete.called is False
 
+    @patch("lighthouse.configs.handler.yaml")
+    def test_sort_yml_extension(self, yaml):
+        yaml.load.return_value = {"port": 8888, "extras": ["foo", "bar"]}
+        modified_event = Mock(src_path="/foo/bar/service.yml")
+
+        target_class = Mock()
+        on_add = Mock()
+        on_update = Mock()
+        on_delete = Mock()
+
+        handler = ConfigFileChangeHandler(
+            target_class, on_add, on_update, on_delete
+        )
+
+        handler.on_modified(modified_event)
+
+        on_update.assert_called_once_with(
+            target_class, "service", yaml.load.return_value
+        )
+        target_class.from_config.assert_called_once_with(
+            "service", yaml.load.return_value
+        )
+        assert on_add.called is False
+        assert on_delete.called is False
+
     def test_on_delete(self):
         deleted_event = Mock(src_path="/foo/bar/service.yaml")
 

--- a/tests/configs/handler_tests.py
+++ b/tests/configs/handler_tests.py
@@ -101,6 +101,27 @@ class ConfigChangeHandlerTests(unittest.TestCase):
         assert on_update.called is False
         assert on_delete.called is False
 
+    @patch("lighthouse.configs.handler.yaml")
+    def test_on_created_from_config_is_none(self, yaml):
+        created_event = Mock(src_path="/foo/bar/service.yaml")
+
+        target_class = Mock()
+        target_class.from_config.return_value = None
+
+        on_add = Mock()
+        on_update = Mock()
+        on_delete = Mock()
+
+        handler = ConfigFileChangeHandler(
+            target_class, on_add, on_update, on_delete
+        )
+
+        handler.on_created(created_event)
+
+        assert on_add.called is False
+        assert on_update.called is False
+        assert on_delete.called is False
+
     @patch("lighthouse.configs.handler.os")
     def test_on_modified_skips_dir_srcpaths(self, mock_os):
         target_class = Mock()

--- a/tests/docstring_tests.py
+++ b/tests/docstring_tests.py
@@ -24,6 +24,7 @@ import lighthouse.haproxy.stanzas.stats
 import lighthouse.log
 import lighthouse.log.cli
 import lighthouse.log.config
+import lighthouse.log.context
 import lighthouse.node
 import lighthouse.peer
 import lighthouse.pluggable
@@ -60,6 +61,7 @@ modules_to_test = (
     lighthouse.log,
     lighthouse.log.cli,
     lighthouse.log.config,
+    lighthouse.log.context,
     lighthouse.node,
     lighthouse.peer,
     lighthouse.pluggable,

--- a/tests/log_tests.py
+++ b/tests/log_tests.py
@@ -10,12 +10,16 @@ from lighthouse import log
 
 class LogTests(unittest.TestCase):
 
-    @patch("lighthouse.log.CLIHandler")
     @patch("lighthouse.log.logging")
-    def test_setup_adds_handler_to_root_logger(self, mock_logging, CLIHandler):
-        log.setup("foobar")
+    def test_setup_returns_root_logger(self, mock_logging):
+        result = log.setup("foobar")
+
+        self.assertEqual(result, mock_logging.getLogger.return_value)
 
         mock_logging.getLogger.assert_called_once_with()
-        mock_logging.getLogger.return_value.addHandler.assert_called_once_with(
-            CLIHandler()
-        )
+
+    @patch("lighthouse.log.ContextFilter")
+    def test_setup_sets_context_filter_program(self, ContextFilter):
+        log.setup("foobar")
+
+        self.assertEqual(ContextFilter.program, "foobar")

--- a/tests/scripts/reporter_tests.py
+++ b/tests/scripts/reporter_tests.py
@@ -1,4 +1,3 @@
-import logging
 try:
     import unittest2 as unittest
 except ImportError:
@@ -14,7 +13,6 @@ from lighthouse.scripts import reporter
 class ReporterScriptTests(unittest.TestCase):
 
     def test_run_handles_keyboardinterrupt(self, parser, Reporter):
-        parser.parse_args.return_value.log_config = None
         Reporter.return_value.start.side_effect = KeyboardInterrupt
 
         reporter.run()
@@ -22,21 +20,7 @@ class ReporterScriptTests(unittest.TestCase):
         Reporter.return_value.stop.assert_called_once_with()
 
     @patch("lighthouse.scripts.reporter.log")
-    def test_debug_flag_set(self, log, parser, Reporter):
-        logger = log.setup.return_value
-
-        parser.parse_args.return_value.debug = True
-
+    def test_log_setup_called(self, log, parser, Reporter):
         reporter.run()
 
-        logger.setLevel.assert_called_once_with(logging.DEBUG)
-
-    @patch("lighthouse.scripts.reporter.log")
-    def test_debug_flag_not_set(self, log, parser, Reporter):
-        logger = log.setup.return_value
-
-        parser.parse_args.return_value.debug = False
-
-        reporter.run()
-
-        logger.setLevel.assert_called_once_with(logging.INFO)
+        log.setup.assert_called_once_with("REPORTER")

--- a/tests/scripts/writer_tests.py
+++ b/tests/scripts/writer_tests.py
@@ -1,4 +1,3 @@
-import logging
 try:
     import unittest2 as unittest
 except ImportError:
@@ -13,20 +12,7 @@ from lighthouse.scripts import writer
 @patch("lighthouse.scripts.writer.parser")
 class WriterScriptTests(unittest.TestCase):
 
-    def reset_log_handler(self):
-        root_logger = logging.getLogger()
-
-        for handler in root_logger.handlers:
-            root_logger.removeHandler(handler)
-
-    def setUp(self):
-        self.reset_log_handler()
-
-    def tearDown(self):
-        self.reset_log_handler()
-
     def test_run_handles_keyboardinterrupt(self, parser, Writer):
-        parser.parse_args.return_value.log_config = None
         Writer.return_value.start.side_effect = KeyboardInterrupt
 
         writer.run()
@@ -34,21 +20,7 @@ class WriterScriptTests(unittest.TestCase):
         Writer.return_value.stop.assert_called_once_with()
 
     @patch("lighthouse.scripts.writer.log")
-    def test_debug_flag_set(self, log, parser, Writer):
-        logger = log.setup.return_value
-
-        parser.parse_args.return_value.debug = True
-
+    def test_log_setup_called(self, log, parser, Writer):
         writer.run()
 
-        logger.setLevel.assert_called_once_with(logging.DEBUG)
-
-    @patch("lighthouse.scripts.writer.log")
-    def test_debug_flag_not_set(self, log, parser, Writer):
-        logger = log.setup.return_value
-
-        parser.parse_args.return_value.debug = False
-
-        writer.run()
-
-        logger.setLevel.assert_called_once_with(logging.INFO)
+        log.setup.assert_called_once_with("WRITER")


### PR DESCRIPTION
Rather than optional flags passed to the scripts, logging is now configured with a yaml file just like the other parts of the system.

Allows for dynamically updating the logging at runtime without stoping/starting the scripts.